### PR TITLE
Repair invalidations during precompilation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,8 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Invalidations" => "invalidations.md",
+        "How PrecompileTools works" => "explanations.md",
         "Reference" => "reference.md",
     ],
 )

--- a/docs/src/explanations.md
+++ b/docs/src/explanations.md
@@ -1,0 +1,26 @@
+# How PrecompileTools works
+
+Julia itself has a function `precompile`, to which you can pass specific signatures to force precompilation.
+For example, `precompile(foo, (ArgType1, ArgType2))` will precompile `foo(::ArgType1, ::ArgType2)` *and all of its inferrable callees*.
+Alternatively, you can just execute some code at "top level" within the module, and during precompilation any method or signature "owned" by your package will also be precompiled.
+Thus, base Julia itself has substantial facilities for precompiling code.
+
+## The `workload` macros
+
+`@compile_workload` adds one key feature: the *non-inferrable callees* (i.e., those called via runtime dispatch) that get
+made inside the `@compile_workload` block will also be cached, *regardless of module ownership*. In essence, it's like you're adding
+an explicit `precompile(noninferrable_callee, (OtherArgType1, ...))` for every runtime-dispatched call made inside `@compile_workload`.
+
+These `workload` macros add other features as well:
+
+- Statements that occur inside a `@compile_workload` block are executed only if the package is being actively precompiled; it does not run when the package is loaded, nor if you're running Julia with `--compiled-modules=no`.
+- Compared to just running some workload at top-level, `@compile_workload` ensures that your code will be compiled (it disables the interpreter inside the block)
+- PrecompileTools also defines `@setup_workload`, which you can use to create data for use inside a `@compile_workload` block. Like `@compile_workload`, this code only runs when you are precompiling the package, but it does not necessarily result in the `@setup_workload` code being stored in the package precompile file.
+
+## `@recompile_invalidations`
+
+`@recompile_invalidations` activates logging of invalidations before executing code in the block.
+It then parses the log to extract the "leaves" of the trees of invalidations, which generally represent
+the top-level calls (typically made by runtime dispatch). It then triggers their recompilation.
+Note that the recompiled code may return different results than the original (this possibility is
+why the code had to be invalidated in the first place).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -175,7 +175,7 @@ end
 
 Note that recompiling invalidations can be useful even if you don't add any additional workloads.
 
-Alternatively, if you're a package developer worried about "collateral damage" from extending functions
+Alternatively, if you're a package developer worried about "collateral damage" you may cause by extending functions
 owned by Base or other package (i.e., those that require `import` or module-scoping when defining the method),
 you can wrap those method definitions:
 
@@ -205,6 +205,16 @@ end
 
 You can have more than one `@recompile_invalidations` block in a module. For example, you might use one to wrap your
 `using`s, and a second to wrap your method extensions.
+
+!!! warning
+    Package developers should be aware of the tradeoffs in using `@recompile_invalidations` to wrap method extensions:
+
+    - the benefit is that you might deliver a better out-of-the-box experience for your users, without them needing to customize anything
+    - the downside is that it will increase the precompilation time for your package. Worse, what can be invalidated once can sometimes be invalidated again by a later package, and if that happens the time spent recompiling is wasted.
+
+    Using `@recompile_invalidations` in a "Startup" package is, in a sense, safer because it waits for all the code to be loaded before recompiling anything. On the other hand, this requires users to implement their own customizations.
+
+    Package developers are encouraged to try to fix "known" invalidations rather than relying reflexively on `@recompile_invalidations`.
 
 ## When you can't run a workload
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -146,6 +146,14 @@ PrecompileTools provides a mechanism to recompile the invalidated code so that y
 of precompilation. This capability can be used in "Startup" packages (like the one described
 above), as well as by package developers.
 
+!!! tip
+    Excepting [piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) (which is heavily discouraged),
+    *type-stable (i.e., well-inferred) code cannot be invalidated.* If invalidations are a problem, an even better option
+    than "healing" the invalidations is improving the inferrability of the "victim": not only will you prevent
+    invalidations, you may get faster performance and slimmer binaries. Packages that can help identify
+    inference problems and invalidations include [SnoopCompile](https://github.com/timholy/SnoopCompile.jl),
+    [JET](https://github.com/aviatesk/JET.jl), and [Cthulhu](https://github.com/JuliaDebug/Cthulhu.jl).
+
 The basic usage is simple: wrap expressions that might invalidate with `@recompile_invalidations`.
 Invalidation can be triggered by defining new methods of external functions, including during
 package loading. Using the "Startup" package above, you might wrap the `using` statements:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,6 +12,8 @@ The main tool in `PrecompileTools` is a macro, `@compile_workload`, which precom
 It also includes a second macro, `@setup_workload`, which can be used to "mark" a block of code as being relevant only
 for precompilation but which does not itself force compilation of `@setup_workload` code. (`@setup_workload` is typically used to generate
 test data using functions that you don't need to precompile in your package.)
+Finally, `PrecompileTools` includes `@recompile_invalidations` to mitigate the undesirable consequences of *invalidations*.
+These different tools are demonstrated below.
 
 ## Tutorial: forcing precompilation with workloads
 
@@ -141,7 +143,7 @@ All the packages will be loaded, together with their precompiled code.
 
 ## Tutorial: "healing" invalidations
 
-Julia sometimes "invalidates" previously compiled code (see [Why does Julia invalidate code?](@ref)).
+Julia sometimes *invalidates* previously compiled code (see [Why does Julia invalidate code?](@ref)).
 PrecompileTools provides a mechanism to recompile the invalidated code so that you get the full benefits
 of precompilation. This capability can be used in "Startup" packages (like the one described
 above), as well as by package developers.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -9,44 +9,44 @@ Julia may be unique among computer languages in supporting all four of the follo
 
 The combination of these features *requires* that you sometimes "throw away" code that you have previously compiled.
 
-To illustrate: suppose you have a function `f` with one method,
+To illustrate: suppose you have a function `numchildren` with one method,
 
 ```
-f(::Any) = 1
+numchildren(::Any) = 1
 ```
 
 and then write
 
 ```
-g(list) = sum(f.(list))
+total_children(list) = sum(numchildren.(list))
 ```
 
-Now let `list` be a `Vector{Any}`. You can compile a fast `g(::Vector{Any})` (*aggressive compilation*) by leveraging the fact that you know there's only one possible method of `f`, and you know that it returns 1
-for every input. Thus, `g(list)` gives you just `length(list)`, which would indeed be a very highly-optimized implementation!
+Now let `list` be a `Vector{Any}`. You can compile a fast `total_children(::Vector{Any})` (*aggressive compilation*) by leveraging the fact that you know there's only one possible method of `numchildren`, and you know that it returns 1
+for every input. Thus, `total_children(list)` gives you just `length(list)`, which would indeed be a very highly-optimized implementation!
 
 But now suppose you add a second method (*interactive development* + *method overloading*)
 
 ```
-f(::MyObj) = 2
+numchildren(::BinaryNode) = 2
 ```
 
-where `MyObj` is some new type you've defined (so it's not type-piracy). If you want to get the right answer (*consistent compilation*) from an arbitrary `list::Vector{Any}`, there are only two options:
+where `BinaryNode` is a new type you've defined (so it's not type-piracy). If you want to get the right answer (*consistent compilation*) from an arbitrary `list::Vector{Any}`, there are only two options:
 
-> **Option A**: plan for this eventuality from the beginning, by making every `f(::Any)` be called by runtime dispatch. But when there is only one method of `f`, forcing runtime dispatch makes the code vastly slower. Thus, this option at least partly violates *aggressive compilation*.
+> **Option A**: plan for this eventuality from the beginning, by making every `numchildren(::Any)` be called by runtime dispatch. But when there is only one method of `numchildren`, forcing runtime dispatch makes the code vastly slower. Thus, this option at least partly violates *aggressive compilation*.
 
-> **Option B**: throw away the code for `g` that you created when there was only one method of `f`, and recompile it in this new world where there are two.
+> **Option B**: throw away the code for `total_children` that you created when there was only one method of `numchildren`, and recompile it in this new world where there are two.
 
 Julia does a mix of these: it does **B** up to 3 methods, and then **A** thereafter. (Recent versions of Julia have experimental support for customizing this behavior with `Base.Experimental.@max_methods`.)
 
-This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `f` and `g`, and `PkgY` might load `PkgX` and define a second method of `PkgX.f`.
+This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `numchildren` and `total_children`, and `PkgY` might load `PkgX` and define a second method of `PkgX.numchildren`.
 Any precompilation that occurs in `PkgX` doesn't know what's going to happen in `PkgY`.
 Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between **A** and **B**.
 
 Given that invalidation is necessary if Julia code is to be both fast and deliver the answers you expect, invalidation is a good thing!
 But sometimes Julia "defensively" throws out code that might be correct but can't be proved to be correct by Julia's type-inference machinery; such cases of "spurious invalidation" serve to (uselessly) increase latency and worsen the Julia experience.
 Except in cases of [piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy), invalidation is a risk
-only for poorly-inferred code. With our example of `f` and `g` above, the invalidations were necessary because `list` was
+only for poorly-inferred code. With our example of `numchildren` and `total_children` above, the invalidations were necessary because `list` was
 a `Vector{Any}`, meaning that the elements might be of `Any` type and therefore Julia can't predict in advance which
-method(s) of `f` would be applicable. Were one to create `list` as, say, `list = Union{MyObj,Int}[]`, Julia would know much more
-about the types of the objects it applies `f` to: a new method like `f(::String)` would not trigger invalidations of code
-that was run on a `list::Vector{Union{MyObj,Int}}`.
+method(s) of `numchildren` would be applicable. Were one to create `list` as, say, `list = Union{BinaryNode,TrinaryNode}[]` (where `TrinaryNode` is some other kind of object with children), Julia would know much more
+about the types of the objects it applies `numchildren` to: yet another new method like `numchildren(::ArbitraryNode)` would not trigger invalidations of code
+that was run on a `list::Vector{Union{BinaryNode,TrinaryNode}}`.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -2,10 +2,10 @@
 
 Julia may be unique among computer languages in supporting all four of the following features:
 
-    1. interactive development
-    2. "method overloading" by packages that don't own the function
-    3. aggressive compilation
-    4. consistent compilation: same result no matter how you got there
+1. interactive development
+2. "method overloading" by packages that don't own the function
+3. aggressive compilation
+4. consistent compilation: same result no matter how you got there
 
 The combination of these features *requires* that you sometimes "throw away" code that you have previously compiled.
 
@@ -32,10 +32,12 @@ f(::MyObj) = 2
 
 where `MyObj` is some new type you've defined (so it's not type-piracy). If you want to get the right answer (*consistent compilation*) from an arbitrary `list::Vector{Any}`, there are only two options:
 
-    a) plan for this eventuality from the beginning, by making every `f(::Any)` be called by runtime dispatch. But if there really is only one method of `f` this is vastly slower, so this at least partly violates *aggressive compilation*.
-    b) throw away the code for `g` that you created when there was only one method of `f`, and recompile it in this new world where there are two.
+> **Option A**: plan for this eventuality from the beginning, by making every `f(::Any)` be called by runtime dispatch. But when there is only one method of `f`, forcing runtime dispatch makes the code vastly slower. Thus, this option at least partly violates *aggressive compilation*.
 
-Julia does a mix of these: it does b) up to 3 methods, and then a) thereafter.
+> **Option B**: throw away the code for `g` that you created when there was only one method of `f`, and recompile it in this new world where there are two.
 
-This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgA` might define `f` and `g`, and `PkgB` might define a second method of `PkgA.f`. Unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between a) and b): any precompilation that occurs
-in PkgA doesn't know what's going to happen in PkgB.
+Julia does a mix of these: it does **B** up to 3 methods, and then **A** thereafter. (Recent versions of Julia have experimental support for customizing this behavior with `Base.Experimental.@max_methods`.)
+
+This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `f` and `g`, and `PkgY` might load `PkgX` and define a second method of `PkgX.f`.
+Any precompilation that occurs in `PkgX` doesn't know what's going to happen in `PkgY`.
+Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between **A** and **B**.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -40,7 +40,7 @@ Julia does a mix of these: it does **B** up to 3 methods, and then **A** thereaf
 
 This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `numchildren` and `total_children`, and `PkgY` might load `PkgX` and define a second method of `PkgX.numchildren`.
 Any precompilation that occurs in `PkgX` doesn't know what's going to happen in `PkgY`.
-Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between **A** and **B**.
+Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between options **A** and **B**.
 
 Given that invalidation is necessary if Julia code is to be both fast and deliver the answers you expect, invalidation is a good thing!
 But sometimes Julia "defensively" throws out code that might be correct but can't be proved to be correct by Julia's type-inference machinery; such cases of "spurious invalidation" serve to (uselessly) increase latency and worsen the Julia experience.
@@ -48,5 +48,5 @@ Except in cases of [piracy](https://docs.julialang.org/en/v1/manual/style-guide/
 only for poorly-inferred code. With our example of `numchildren` and `total_children` above, the invalidations were necessary because `list` was
 a `Vector{Any}`, meaning that the elements might be of `Any` type and therefore Julia can't predict in advance which
 method(s) of `numchildren` would be applicable. Were one to create `list` as, say, `list = Union{BinaryNode,TrinaryNode}[]` (where `TrinaryNode` is some other kind of object with children), Julia would know much more
-about the types of the objects it applies `numchildren` to: yet another new method like `numchildren(::ArbitraryNode)` would not trigger invalidations of code
-that was run on a `list::Vector{Union{BinaryNode,TrinaryNode}}`.
+about the types of the objects to which it applies `numchildren`: defining yet another new method like `numchildren(::ArbitraryNode)` would not trigger invalidations of code
+that was compiled for a `list::Vector{Union{BinaryNode,TrinaryNode}}`.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -41,3 +41,12 @@ Julia does a mix of these: it does **B** up to 3 methods, and then **A** thereaf
 This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `f` and `g`, and `PkgY` might load `PkgX` and define a second method of `PkgX.f`.
 Any precompilation that occurs in `PkgX` doesn't know what's going to happen in `PkgY`.
 Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between **A** and **B**.
+
+Given that invalidation is necessary if Julia code is to be both fast and deliver the answers you expect, invalidation is a good thing!
+But sometimes Julia "defensively" throws out code that might be correct but can't be proved to be correct by Julia's type-inference machinery; such cases of "spurious invalidation" serve to (uselessly) increase latency and worsen the Julia experience.
+Except in cases of [piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy), invalidation is a risk
+only for poorly-inferred code. With our example of `f` and `g` above, the invalidations were necessary because `list` was
+a `Vector{Any}`, meaning that the elements might be of `Any` type and therefore Julia can't predict in advance which
+method(s) of `f` would be applicable. Were one to create `list` as, say, `list = Union{MyObj,Int}[]`, Julia would know much more
+about the types of the objects it applies `f` to: a new method like `f(::String)` would not trigger invalidations of code
+that was run on a `list::Vector{Union{MyObj,Int}}`.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -1,0 +1,41 @@
+# Why does Julia invalidate code?
+
+Julia may be unique among computer languages in supporting all four of the following features:
+
+    1. interactive development
+    2. "method overloading" by packages that don't own the function
+    3. aggressive compilation
+    4. consistent compilation: same result no matter how you got there
+
+The combination of these features *requires* that you sometimes "throw away" code that you have previously compiled.
+
+To illustrate: suppose you have a function `f` with one method,
+
+```
+f(::Any) = 1
+```
+
+and then write
+
+```
+g(list) = sum(f.(list))
+```
+
+Now let `list` be a `Vector{Any}`. You can compile a fast `g(::Vector{Any})` (*aggressive compilation*) by leveraging the fact that you know there's only one possible method of `f`, and you know that it returns 1
+for every input. Thus, `g(list)` gives you just `length(list)`, which would indeed be a very highly-optimized implementation!
+
+But now suppose you add a second method (*interactive development* + *method overloading*)
+
+```
+f(::MyObj) = 2
+```
+
+where `MyObj` is some new type you've defined (so it's not type-piracy). If you want to get the right answer (*consistent compilation*) from an arbitrary `list::Vector{Any}`, there are only two options:
+
+    a) plan for this eventuality from the beginning, by making every `f(::Any)` be called by runtime dispatch. But if there really is only one method of `f` this is vastly slower, so this at least partly violates *aggressive compilation*.
+    b) throw away the code for `g` that you created when there was only one method of `f`, and recompile it in this new world where there are two.
+
+Julia does a mix of these: it does b) up to 3 methods, and then a) thereafter.
+
+This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgA` might define `f` and `g`, and `PkgB` might define a second method of `PkgA.f`. Unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between a) and b): any precompilation that occurs
+in PkgA doesn't know what's going to happen in PkgB.

--- a/docs/src/invalidations.md
+++ b/docs/src/invalidations.md
@@ -40,7 +40,7 @@ Julia does a mix of these: it does **B** up to 3 methods, and then **A** thereaf
 
 This example was framed as an experiment at the REPL, but it is also relevant if you load two packages: `PkgX` might define `numchildren` and `total_children`, and `PkgY` might load `PkgX` and define a second method of `PkgX.numchildren`.
 Any precompilation that occurs in `PkgX` doesn't know what's going to happen in `PkgY`.
-Therefore, unless you want to defer *all* compilation (including for `Base`) until the entire session is loaded and then closed to further extension, you have to make the same choice between options **A** and **B**.
+Therefore, unless you want to defer *all* compilation, including for Julia itself, until the entire session is loaded and then closed to further extension (similar to how compilers for C, Rust, etc. work), you have to make the same choice between options **A** and **B**.
 
 Given that invalidation is necessary if Julia code is to be both fast and deliver the answers you expect, invalidation is a good thing!
 But sometimes Julia "defensively" throws out code that might be correct but can't be proved to be correct by Julia's type-inference machinery; such cases of "spurious invalidation" serve to (uselessly) increase latency and worsen the Julia experience.

--- a/src/PrecompileTools.jl
+++ b/src/PrecompileTools.jl
@@ -3,151 +3,25 @@ module PrecompileTools
 if VERSION >= v"1.6"
     using Preferences
 end
-export @setup_workload, @compile_workload
+export @setup_workload, @compile_workload, @recompile_invalidations
 
 const verbose = Ref(false)    # if true, prints all the precompiles
 const have_inference_tracking = isdefined(Core.Compiler, :__set_measure_typeinf)
 const have_force_compile = isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("#@force_compile"))
 
-function workload_enabled(mod::Module)
-    try
-        load_preference(mod, "precompile_workload", true)
-    catch
-        true
-    end
+function precompile_mi(mi)
+    precompile(mi.specTypes) # TODO: Julia should allow one to pass `mi` directly (would handle `invoke` properly)
+    verbose[] && println(mi)
+    return
 end
 
-"""
-    check_edges(node)
-
-Recursively ensure that all callees of `node` are precompiled. This is (rarely) necessary
-because sometimes there is no backedge from callee to caller (xref https://github.com/JuliaLang/julia/issues/49617),
-and `staticdata.c` relies on the backedge to trace back to a MethodInstance that is tagged `mi.precompiled`.
-"""
-function check_edges(node)
-    parentmi = node.mi_info.mi
-    for child in node.children
-        childmi = child.mi_info.mi
-        if !(isdefined(childmi, :backedges) && parentmi ∈ childmi.backedges)
-            precompile(childmi.specTypes)
-        end
-        check_edges(child)
+include("workloads.jl")
+if VERSION >= v"1.9.0-rc2"
+    include("invalidations.jl")
+else
+    macro recompile_invalidations(ex::Expr)
+        return esc(ex)
     end
-end
-
-function precompile_roots(roots)
-    @assert have_inference_tracking
-    for child in roots
-        mi = child.mi_info.mi
-        precompile(mi.specTypes) # TODO: Julia should allow one to pass `mi` directly (would handle `invoke` properly)
-        verbose[] && println(mi)
-        check_edges(child)
-    end
-end
-
-"""
-    @compile_workload f(args...)
-
-`precompile` (and save in the compile_workload file) any method-calls that occur inside the expression. All calls (direct or indirect) inside a
-`@compile_workload` block will be cached.
-
-`@compile_workload` has three key features:
-
-1. code inside runs only when the package is being precompiled (i.e., a `*.ji`
-   precompile compile_workload file is being written)
-2. the interpreter is disabled, ensuring your calls will be compiled
-3. both direct and indirect callees will be precompiled, even for methods defined in other packages
-   and even for runtime-dispatched callees (requires Julia 1.8 and above).
-
-!!! note
-    For comprehensive precompilation, ensure the first usage of a given method/argument-type combination
-    occurs inside `@compile_workload`.
-
-    In detail: runtime-dispatched callees are captured only when type-inference is executed, and they
-    are inferred only on first usage. Inferrable calls that trace back to a method defined in your package,
-    and their *inferrable* callees, will be precompiled regardless of "ownership" of the callees
-    (Julia 1.8 and higher).
-
-    Consequently, this recommendation matters only for:
-
-        - direct calls to methods defined in Base or other packages OR
-        - indirect runtime-dispatched calls to such methods.
-"""
-macro compile_workload(ex::Expr)
-    local iscompiling = if Base.VERSION < v"1.6"
-        :(ccall(:jl_generating_output, Cint, ()) == 1)
-    else
-        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
-    end
-    if have_force_compile
-        ex = quote
-            begin
-                Base.Experimental.@force_compile
-                $ex
-            end
-        end
-    else
-        # Use the hack on earlier Julia versions that blocks the interpreter
-        ex = quote
-            while false end
-            $ex
-        end
-    end
-    if have_inference_tracking
-        ex = quote
-            Core.Compiler.Timings.reset_timings()
-            Core.Compiler.__set_measure_typeinf(true)
-            try
-                $ex
-            finally
-                Core.Compiler.__set_measure_typeinf(false)
-                Core.Compiler.Timings.close_current_timer()
-            end
-            $PrecompileTools.precompile_roots(Core.Compiler.Timings._timings[1].children)
-        end
-    end
-    return esc(quote
-        if $iscompiling || $PrecompileTools.verbose[]
-            $ex
-        end
-    end)
-end
-
-"""
-    @setup_workload begin
-        vars = ...
-        ⋮
-    end
-
-Run the code block only during package precompilation. `@setup_workload` is often used in combination
-with [`@compile_workload`](@ref), for example:
-
-    @setup_workload begin
-        vars = ...
-        @compile_workload begin
-            y = f(vars...)
-            g(y)
-            ⋮
-        end
-    end
-
-`@setup_workload` does not force compilation (though it may happen anyway) nor intentionally capture
-runtime dispatches (though they will be precompiled anyway if the runtime-callee is for a method belonging
-to your package).
-"""
-macro setup_workload(ex::Expr)
-    local iscompiling = if Base.VERSION < v"1.6"
-        :(ccall(:jl_generating_output, Cint, ()) == 1)
-    else
-        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
-    end
-    return esc(quote
-        let
-            if $iscompiling || $PrecompileTools.verbose[]
-                $ex
-            end
-        end
-    end)
 end
 
 end

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -48,12 +48,6 @@ function invalidation_leaves(invlist)
                     cachequeued(nothing, 0)
                     push!(umis, item)
                 end
-                # if nextitem == "verify_methods"
-                #     # Skip over the cause, which can also be a MethodInstance
-                #     # These may be superseded, but they aren't technically invalidated
-                #     # (e.g., could still be called via `invoke`)
-                #     i += 2
-                # end
                 if isa(nextitem, Integer)
                     cachequeued(item, nextitem)
                     i += 2

--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -1,0 +1,71 @@
+"""
+    @recompile_invalidations begin
+        using PkgA
+        ⋮
+    end
+
+Recompile any invalidations that occur within the given expression. This is generally intended to be used
+by users in creating "Startup" packages to ensure that the code compiled by package authors is not invalidated.
+"""
+macro recompile_invalidations(expr)
+    list = gensym(:list)
+    Expr(:toplevel,
+        :($list = ccall(:jl_debug_method_invalidation, Any, (Cint,), 1)),
+        Expr(:tryfinally,
+            esc(expr),
+            :(ccall(:jl_debug_method_invalidation, Any, (Cint,), 0))
+        ),
+        :(if ccall(:jl_generating_output, Cint, ()) == 1
+            foreach($PrecompileTools.precompile_mi, $PrecompileTools.invalidation_leaves($list))
+          end)
+    )
+end
+
+function invalidation_leaves(invlist)
+    umis = Set{Core.MethodInstance}()
+    # `queued` is a queue of length 0 or 1 of invalidated MethodInstances.
+    # We wait to read the `depth` to find out if it's a leaf.
+    queued, depth = nothing, 0
+    function cachequeued(item, nextdepth)
+        if queued !== nothing && nextdepth <= depth
+            push!(umis, queued)
+        end
+        queued, depth = item, nextdepth
+    end
+
+    i, ilast = firstindex(invlist), lastindex(invlist)
+    while i <= ilast
+        item = invlist[i]
+        if isa(item, Core.MethodInstance)
+            if i < lastindex(invlist)
+                nextitem = invlist[i+1]
+                if nextitem == "invalidate_mt_cache"
+                    cachequeued(nothing, 0)
+                    i += 2
+                    continue
+                end
+                if nextitem ∈ ("jl_method_table_disable", "jl_method_table_insert", "verify_methods")
+                    cachequeued(nothing, 0)
+                    push!(umis, item)
+                end
+                # if nextitem == "verify_methods"
+                #     # Skip over the cause, which can also be a MethodInstance
+                #     # These may be superseded, but they aren't technically invalidated
+                #     # (e.g., could still be called via `invoke`)
+                #     i += 2
+                # end
+                if isa(nextitem, Integer)
+                    cachequeued(item, nextitem)
+                    i += 2
+                    continue
+                end
+            end
+        end
+        if (isa(item, Method) || isa(item, Type)) && queued !== nothing
+            push!(umis, queued)
+            queued, depth = nothing, 0
+        end
+        i += 1
+    end
+    return umis
+end

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -1,0 +1,139 @@
+
+function workload_enabled(mod::Module)
+    try
+        load_preference(mod, "precompile_workload", true)
+    catch
+        true
+    end
+end
+
+"""
+    check_edges(node)
+
+Recursively ensure that all callees of `node` are precompiled. This is (rarely) necessary
+because sometimes there is no backedge from callee to caller (xref https://github.com/JuliaLang/julia/issues/49617),
+and `staticdata.c` relies on the backedge to trace back to a MethodInstance that is tagged `mi.precompiled`.
+"""
+function check_edges(node)
+    parentmi = node.mi_info.mi
+    for child in node.children
+        childmi = child.mi_info.mi
+        if !(isdefined(childmi, :backedges) && parentmi ∈ childmi.backedges)
+            precompile_mi(childmi)
+        end
+        check_edges(child)
+    end
+end
+
+function precompile_roots(roots)
+    @assert have_inference_tracking
+    for child in roots
+        precompile_mi(child.mi_info.mi)
+        check_edges(child)
+    end
+end
+
+"""
+    @compile_workload f(args...)
+
+`precompile` (and save in the compile_workload file) any method-calls that occur inside the expression. All calls (direct or indirect) inside a
+`@compile_workload` block will be cached.
+
+`@compile_workload` has three key features:
+
+1. code inside runs only when the package is being precompiled (i.e., a `*.ji`
+   precompile compile_workload file is being written)
+2. the interpreter is disabled, ensuring your calls will be compiled
+3. both direct and indirect callees will be precompiled, even for methods defined in other packages
+   and even for runtime-dispatched callees (requires Julia 1.8 and above).
+
+!!! note
+    For comprehensive precompilation, ensure the first usage of a given method/argument-type combination
+    occurs inside `@compile_workload`.
+
+    In detail: runtime-dispatched callees are captured only when type-inference is executed, and they
+    are inferred only on first usage. Inferrable calls that trace back to a method defined in your package,
+    and their *inferrable* callees, will be precompiled regardless of "ownership" of the callees
+    (Julia 1.8 and higher).
+
+    Consequently, this recommendation matters only for:
+
+        - direct calls to methods defined in Base or other packages OR
+        - indirect runtime-dispatched calls to such methods.
+"""
+macro compile_workload(ex::Expr)
+    local iscompiling = if Base.VERSION < v"1.6"
+        :(ccall(:jl_generating_output, Cint, ()) == 1)
+    else
+        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
+    end
+    if have_force_compile
+        ex = quote
+            begin
+                Base.Experimental.@force_compile
+                $ex
+            end
+        end
+    else
+        # Use the hack on earlier Julia versions that blocks the interpreter
+        ex = quote
+            while false end
+            $ex
+        end
+    end
+    if have_inference_tracking
+        ex = quote
+            Core.Compiler.Timings.reset_timings()
+            Core.Compiler.__set_measure_typeinf(true)
+            try
+                $ex
+            finally
+                Core.Compiler.__set_measure_typeinf(false)
+                Core.Compiler.Timings.close_current_timer()
+            end
+            $PrecompileTools.precompile_roots(Core.Compiler.Timings._timings[1].children)
+        end
+    end
+    return esc(quote
+        if $iscompiling || $PrecompileTools.verbose[]
+            $ex
+        end
+    end)
+end
+
+"""
+    @setup_workload begin
+        vars = ...
+        ⋮
+    end
+
+Run the code block only during package precompilation. `@setup_workload` is often used in combination
+with [`@compile_workload`](@ref), for example:
+
+    @setup_workload begin
+        vars = ...
+        @compile_workload begin
+            y = f(vars...)
+            g(y)
+            ⋮
+        end
+    end
+
+`@setup_workload` does not force compilation (though it may happen anyway) nor intentionally capture
+runtime dispatches (though they will be precompiled anyway if the runtime-callee is for a method belonging
+to your package).
+"""
+macro setup_workload(ex::Expr)
+    local iscompiling = if Base.VERSION < v"1.6"
+        :(ccall(:jl_generating_output, Cint, ()) == 1)
+    else
+        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
+    end
+    return esc(quote
+        let
+            if $iscompiling || $PrecompileTools.verbose[]
+                $ex
+            end
+        end
+    end)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,4 +92,102 @@ using UUIDs
         end
         PrecompileTools.verbose[] = oldval
     end
+
+    if isdefined(PrecompileTools, :invalidation_leaves)
+        # Mimic the format written to `_jl_debug_method_invalidation`
+        # As a source of MethodInstances, `getproperty` has lots
+        m = which(getproperty, (Any, Symbol))
+        mis = Core.MethodInstance[]
+        for mi in specializations(m)
+            length(mis) >= 10 && break
+            mi === nothing && continue
+            push!(mis, mi)
+        end
+        # These mimic the invalidation lists in SnoopCompile's `test/snoopr.jl`
+        invs = Any[mis[1], 0, mis[2], 1, Tuple{}, m, "jl_method_table_insert"]
+        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
+        invs = Any[mis[1], 0, mis[2], 1, mis[3], 1, Tuple{}, m, "jl_method_table_insert"]
+        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2], mis[3]])
+        invs = Any[mis[1], 0, mis[2], 1, Tuple{}, mis[1], 1, mis[3], "jl_method_table_insert", m, "jl_method_table_insert"]
+        @test PrecompileTools.invalidation_leaves(invs) == Set(mis[1:3])
+        invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", m, "jl_method_table_disable"]
+        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
+        invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", mis[3], "jl_method_table_insert", m]
+        @test Set([mis[1], mis[2]]) ⊆ PrecompileTools.invalidation_leaves(invs)
+        invs = Any[mis[1], 1, mis[2], "jl_method_table_insert", mis[2], "invalidate_mt_cache", m, "jl_method_table_insert"]
+        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
+        invs = Any[Tuple{}, "insert_backedges_callee", 55, Any[m], mis[2], "verify_methods", 55]
+        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
+
+        # Add a real invalidation & repair test
+        cproj = Base.active_project()
+        mktempdir() do dir
+            push!(LOAD_PATH, dir)
+            cd(dir) do
+                for ((pkg1, pkg2, pkg3), recompile) in ((("RC_A", "RC_B", "RC_C"), false,),
+                                                        (("RC_D", "RC_E", "RC_F"), true))
+                    Pkg.generate(pkg1)
+                    open(joinpath(dir, pkg1, "src", pkg1*".jl"), "w") do io
+                        println(io, """
+                        module $pkg1
+                        nbits(::Int8) = 8
+                        nbits(::Int16) = 16
+                        call_nbits(c) = nbits(only(c))
+                        begin
+                            Base.Experimental.@force_compile
+                            call_nbits(Any[Int8(5)])
+                        end
+                        end
+                        """)
+                    end
+                    Pkg.generate(pkg2)
+                    Pkg.activate(joinpath(dir, pkg2))
+                    Pkg.develop(PackageSpec(path=joinpath(dir, pkg1)))
+                    open(joinpath(dir, pkg2, "src", pkg2*".jl"), "w") do io
+                        println(io, """
+                        module $pkg2
+                        using $pkg1
+                        $(pkg1).nbits(::Int32) = 32
+                        end
+                        """)
+                    end
+                    # pkg3 is like a "Startup" package that recompiles the invalidations from loading the "code universe"
+                    Pkg.generate(pkg3)
+                    Pkg.activate(joinpath(dir, pkg3))
+                    Pkg.develop(PackageSpec(path=joinpath(dir, pkg2)))
+                    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))   # depend on PrecompileTools
+                    open(joinpath(dir, pkg3, "src", pkg3*".jl"), "w") do io
+                        if recompile
+                            println(io, """
+                            module $pkg3
+                            using PrecompileTools
+                            @recompile_invalidations using $pkg2
+                            end
+                            """)
+                        else
+                            println(io, """
+                            module $pkg3
+                            using PrecompileTools
+                            using $pkg2
+                            end
+                            """)
+                        end
+                    end
+
+                    @eval using $(Symbol(pkg3))
+                    mod3 = getglobal(@__MODULE__, Symbol(pkg3))
+                    mod2 = getglobal(mod3, Symbol(pkg2))
+                    mod1 = getglobal(mod2, Symbol(pkg1))
+                    m = only(methods(mod1.call_nbits))
+                    mi = first(specializations(m))
+                    wc = Base.get_world_counter()
+                    @test recompile ? mi.cache.max_world >= wc : mi.cache.max_world < wc
+                end
+            end
+            pop!(LOAD_PATH)
+        end
+        Pkg.activate(cproj)
+    end
+
+    pop!(LOAD_PATH)
 end


### PR DESCRIPTION
This allows one to monitor invalidations and recompile them.
The main targets are "Startup" packages that load other packages that
may not know about one another, although there does not appear
to be any reason that "regular" packages couldn't use it too.

Hint to potential reviewers: aside from the new tests and docs, only the code in `invalidations.jl` is new. The rest is just moved around.