### PR TITLE
Catch errors during precompilation

### DIFF
--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -126,7 +126,7 @@ macro compile_workload(ex::Expr)
                     An error occurred while precompiling $(@__MODULE__) during `PrecompileTools.@compile_workload`.
                     Please resolve the errors and run `touch(pathof($(@__MODULE__))); Pkg.precompile(\"$(@__MODULE__)\")`."
                     """ exception=(err,bt)
-                    err,bt
+                    err
                 end
             end
         end
@@ -178,7 +178,7 @@ macro setup_workload(ex::Expr)
                     An error occurred while precompiling $(@__MODULE__) during `PrecompileTools.@setup_workload`.
                     Please resolve the errors and run `touch(pathof($(@__MODULE__))); Pkg.precompile(\"$(@__MODULE__)\")`."
                     """ exception=(err,bt)
-                    err, bt
+                    err
                 end
             end
         end

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -113,7 +113,7 @@ macro compile_workload(ex::Expr)
         end
     end
     return esc(quote
-        const __PrecompileTools_setup_workload_error = if $iscompiling || $PrecompileTools.verbose[]
+        __PrecompileTools_setup_workload_error = if $iscompiling || $PrecompileTools.verbose[]
             try
                 $ex
                  nothing

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -118,7 +118,7 @@ macro compile_workload(ex::Expr)
                 $ex
                  nothing
             catch err
-                if $throw_error
+                if $throw_error || err isa UndefVarError
                     throw(err)
                 else
                     bt = catch_backtrace()
@@ -170,7 +170,7 @@ macro setup_workload(ex::Expr)
                 $ex
                  nothing
             catch err
-                if $throw_error
+                if $throw_error || err isa UndefVarError
                     throw(err)
                 else
                     bt = catch_backtrace()

--- a/test/PC_F/Manifest.toml
+++ b/test/PC_F/Manifest.toml
@@ -1,0 +1,33 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.0"
+manifest_format = "2.0"
+project_hash = "720db4e5897c289ff8ff2e581fe8e02829da8989"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+path = "../.."
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/PC_F/Project.toml
+++ b/test/PC_F/Project.toml
@@ -1,0 +1,7 @@
+name = "PC_F"
+uuid = "84e86b7e-6e80-4b10-9617-7cfc0028c0f3"
+authors = ["Mark Kittisopikul <markkitt@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"

--- a/test/PC_F/src/PC_F.jl
+++ b/test/PC_F/src/PC_F.jl
@@ -1,0 +1,7 @@
+module PC_F
+    using PrecompileTools
+
+    @compile_workload begin
+        throw(error("This is a very serious error during precompilaton"))
+    end
+end


### PR DESCRIPTION
Here we catch errors during precompilation so that the user still has the possibility of loading the package for diagnostics.