### PR TITLE
add note about possible performance regressions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,7 @@ Finally, `PrecompileTools` includes `@recompile_invalidations` to mitigate the u
 These different tools are demonstrated below.
 
 !!! note
-    There have been cases where precompilation led to performance regressions in packages (see for example [[1](https://github.com/JuliaLang/julia/issues/50749),[2](https://github.com/JuliaLang/julia/pull/50766),[3](https://github.com/JuliaLang/julia/issues/35972)]). While fixes have been released, some problems persist in older Julia versions and new issues might also slow down runtime after precompilation. Hence, it's advised to test packages for performance regressions in all supported Julia versions when introducing precompilation directives.
+    The latency reductions from PrecompileTools are maximally effective for Julia versions 1.9 and higher, and intermediate for Julia 1.8. Julia versions 1.7 and earlier may see some limited benefit as well, but have also occasionally been found to suffer from [precompilation-induced runtime performance regressions](https://github.com/JuliaLang/julia/issues/35972). If you wish, you can disable precompilation on older Julia versions by wrapping precompilation statements (see below) with `if Base.VERSION >= v"1.8" ... end`. On older Julia versions, you may wish to test packages for performance regressions when introducing precompilation directives.
 
 ## Tutorial: forcing precompilation with workloads
 


### PR DESCRIPTION
Add note about possible performance regressions after adding precompilation directives, which are Julia-version dependent. 