### PR TITLE
Avoid plain "using PrecompileTools" in example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,7 +27,7 @@ Here's an illustration of how you might use `@compile_workload` and `@setup_work
 ```julia
 module MyPackage
 
-using PrecompileTools    # this is a small dependency
+using PrecompileTools: @setup_workload, @compile_workload    # this is a small dependency
 
 struct MyType
     x::Int


### PR DESCRIPTION
According to https://github.com/JuliaLang/julia/pull/42080 

> Doing `using Foo` in packages or code that you want to keep working with
    updated dependencies is not recommended. The reason for this is if another
    dependency starts to export one of the same names as `Foo` the code will
    error due to an ambiguity in which package the name should be taken from.
    Instead, explicitly list what names you want to use from Foo, for example:
    `using Foo: Foo, parsefile, readfile` to get access bring `Foo` and two
    functions `parsefile` and `readfile` into scope.