### PR TITLE
quality improvement for recompile_invalidations

### DIFF
--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -8,14 +8,14 @@ Recompile any invalidations that occur within the given expression. This is gene
 by users in creating "Startup" packages to ensure that the code compiled by package authors is not invalidated.
 """
 macro recompile_invalidations(expr)
-    # use QuoteNode instead of Expr(:quote) so that $ is not permitted as usual (instead of having this macro work like `@eval`)
+    # use QuoteNode instead of esc(Expr(:quote)) so that $ is not permitted as usual (instead of having this macro work like `@eval`)
     return :(recompile_invalidations($__module__, $(QuoteNode(expr))))
 end
 
 function recompile_invalidations(__module__::Module, @nospecialize expr)
     list = ccall(:jl_debug_method_invalidation, Any, (Cint,), 1)
     try
-        eval(__module__, expr)
+        Core.eval(__module__, expr)
     finally
         ccall(:jl_debug_method_invalidation, Any, (Cint,), 0)
     end


### PR DESCRIPTION
The previous implementation was unnecessarily forcing compilation of the wrapper code for each use of the macro, and was assuming that hygiene rules do not apply to a gensym in a toplevel block and assuming that the internal tryfinally syntax is legal to generate directly. This change tries to avoid all of those assumptions, and should therefore also give better backtraces too.