### PR TITLE
Stear the user towards let

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ struct OtherType
     str::String
 end
 
-@setup_workload begin
+@setup_workload let
     # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
     # precompile file and potentially make loading faster.
     list = [OtherType("hello"), OtherType("world!")]

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -106,7 +106,7 @@ macro compile_workload(ex::Expr)
 end
 
 """
-    @setup_workload begin
+    @setup_workload let
         vars = ...
         ⋮
     end
@@ -114,7 +114,7 @@ end
 Run the code block only during package precompilation. `@setup_workload` is often used in combination
 with [`@compile_workload`](@ref), for example:
 
-    @setup_workload begin
+    @setup_workload let
         vars = ...
         @compile_workload begin
             y = f(vars...)

--- a/test/PC_A/src/PC_A.jl
+++ b/test/PC_A/src/PC_A.jl
@@ -17,7 +17,7 @@ function call_findfirst(x, list)
     return findfirst(==(inferencebarrier(x)), inferencebarrier(list))
 end
 
-@setup_workload begin
+@setup_workload let
     list = [MyType(1), MyType(2), MyType(3)]
     @compile_workload begin
         call_findfirst(MyType(2), list)

--- a/test/PC_C/src/PC_C.jl
+++ b/test/PC_C/src/PC_C.jl
@@ -22,7 +22,7 @@ module RB
 end
 using .RB
 
-@setup_workload begin
+@setup_workload let
     struct Foo end
     @compile_workload begin
         @recipe f(::Foo) = nothing

--- a/test/PC_D/src/PC_D.jl
+++ b/test/PC_D/src/PC_D.jl
@@ -3,7 +3,7 @@ module PC_D
 using PrecompileTools
 using PrecompileTools.Preferences
 
-@setup_workload begin
+@setup_workload let
     @compile_workload begin
         global workload_ran = true
     end

--- a/test/PC_E/src/PC_E.jl
+++ b/test/PC_E/src/PC_E.jl
@@ -10,7 +10,7 @@ g(list) = [f(x) for x in list]
 
 using PrecompileTools
 
-@setup_workload begin
+@setup_workload let
     list = Any[1, "hi"]
     @compile_workload begin
         for item in list


### PR DESCRIPTION
`begin` is a soft-scope so global variables created within are rooted through the module.

Instead users should use `let` so that the setup data is GC'd and not serialized into the cache file.