### PR TITLE
Fix typo in docs repolink

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(;
     authors="Tim Holy <tim.holy@gmail.com>, t-bltg <tf.bltg@gmail.com>, and contributors",
     sitename="PrecompileTools.jl",
     format=Documenter.HTML(;
-        repolink="https://github.com/JuliaLang/PrecompileTools.j/",
+        repolink="https://github.com/JuliaLang/PrecompileTools.jl/",
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://JuliaLang.github.io/PrecompileTools.jl",
         edit_link="main",


### PR DESCRIPTION
This PR fixes a minor typo in the docs which breaks the "view code on github" link.