### PR TITLE
Support PrecompileTools on nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'
+          - '1.12-nightly'    # FIXME change to 1.12 when released
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: 'nightly'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
-          - '1'
+          - '1.12'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "PrecompileTools"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 authors = ["Tim Holy <tim.holy@gmail.com>", "t-bltg <tf.bltg@gmail.com>", "and contributors"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 Preferences = "1"
-julia = "1"
+julia = "1.12"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.0"
+julia_version = "1.13.0-DEV"
 manifest_format = "2.0"
-project_hash = "6fd069b8f2a6f80151541100222c8411b19a2545"
+project_hash = "333a4266b4d44fdbc59a46e944e3f36458e24359"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -10,23 +10,32 @@ uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
 [[deps.AbstractTrees]]
-git-tree-sha1 = "faa260e4cb5aba097a73fab382dd4b5819d8ec8c"
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-version = "0.4.4"
+version = "0.4.5"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -35,52 +44,54 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.3"
 
 [[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "Test", "Unicode"]
-git-tree-sha1 = "2613dbec8f4748273bbe30ba71fd5cb369966bac"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "30f520c66490393bf4e4ff2bb144db65f569d974"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.2.1"
+version = "1.9.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "4558ab818dcceaab612d1bb8c19cee87eda2b83c"
+git-tree-sha1 = "d55dffd9ae73ff72f1c0482454dcf2ec6c6c4a63"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.5.0+0"
+version = "2.6.5+0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.Git]]
 deps = ["Git_jll"]
-git-tree-sha1 = "51764e6c2e84c37055e846c516e9015b4a291c7d"
+git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "b30c473c97fcc1e1e44fab8f3e88fd1b89c9e9d1"
+git-tree-sha1 = "399f4a308c804b446ae4c91eeafadb2fe2c54ff9"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.43.0+0"
+version = "2.47.1+0"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "8b72179abc660bfab5e28472e019392b97d0985c"
+git-tree-sha1 = "b6d6bfdd7ce25b0f9b2f6b3dd56b2673a66c8770"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.4"
+version = "0.2.5"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.7.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -88,10 +99,15 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
 [[deps.LazilyInitializedFields]]
-git-tree-sha1 = "8f7f3cabab0fd1800699663533b6d5cb3fc0e612"
+git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
 uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
-version = "1.2.2"
+version = "1.3.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -99,39 +115,43 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.12.1+1"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "f9557a255370125b405568f9767d6d195822a175"
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.17.0+0"
+version = "1.18.0+0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MarkdownAST]]
 deps = ["AbstractTrees", "Markdown"]
@@ -139,32 +159,27 @@ git-tree-sha1 = "465a70f0fc7d443a00dcdc3267a497397b8a3899"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 version = "0.1.2"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
-
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2024.12.31"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "60e3045590bd104a16fefb12836c00c0ef8c7f8c"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.13+0"
+version = "3.0.16+0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -173,33 +188,40 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.8.1"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.12.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-path = ".."
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.3"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.RegistryInstances]]
 deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
@@ -213,9 +235,15 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -230,25 +258,33 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.65.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.5.0+2"

--- a/src/PrecompileTools.jl
+++ b/src/PrecompileTools.jl
@@ -7,7 +7,7 @@ export @setup_workload, @compile_workload, @recompile_invalidations
 const verbose = Ref(false)    # if true, prints all the precompiles
 
 function precompile_mi(mi::Core.MethodInstance)
-    precompile(mi.specTypes) # TODO: Julia should allow one to pass `mi` directly (would handle `invoke` properly)
+    precompile(mi)
     verbose[] && println(mi)
     return
 end

--- a/src/PrecompileTools.jl
+++ b/src/PrecompileTools.jl
@@ -1,27 +1,18 @@
 module PrecompileTools
 
-if VERSION >= v"1.6"
-    using Preferences
-end
+using Preferences
+
 export @setup_workload, @compile_workload, @recompile_invalidations
 
 const verbose = Ref(false)    # if true, prints all the precompiles
-const have_inference_tracking = isdefined(Core.Compiler, :__set_measure_typeinf)
-const have_force_compile = isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("#@force_compile"))
 
-function precompile_mi(mi)
+function precompile_mi(mi::Core.MethodInstance)
     precompile(mi.specTypes) # TODO: Julia should allow one to pass `mi` directly (would handle `invoke` properly)
     verbose[] && println(mi)
     return
 end
 
 include("workloads.jl")
-if VERSION >= v"1.9.0-rc2"
-    include("invalidations.jl")
-else
-    macro recompile_invalidations(ex::Expr)
-        return esc(ex)
-    end
-end
+include("invalidations.jl")
 
 end

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -12,11 +12,15 @@ function workload_enabled(mod::Module)
     end
 end
 
-function precompile_newly_inferred(cis)
-    while !isempty(cis)
-        ci = pop!(cis)
-        precompile_mi(ci.def)
-    end
+@noinline function precompile_newly_inferred(cis)
+        ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing) # ensure we drop internally references to both newly_inferred arrays so that it is safe to access them here
+        for child in cis # set the must-precompile bit on all new code
+            precompile_mi((child::Base.CodeInstance).def)
+        end
+        append!(Base.newly_inferred, cis) # request the new code be included in the serialized file
+        empty!(newly_inferred)
+        nothing
+end
     return cis
 end
 

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -1,3 +1,4 @@
+const newly_inferred = Core.CodeInstance[]
 
 function workload_enabled(mod::Module)
     try
@@ -11,30 +12,12 @@ function workload_enabled(mod::Module)
     end
 end
 
-"""
-    check_edges(node)
-
-Recursively ensure that all callees of `node` are precompiled. This is (rarely) necessary
-because sometimes there is no backedge from callee to caller (xref https://github.com/JuliaLang/julia/issues/49617),
-and `staticdata.c` relies on the backedge to trace back to a MethodInstance that is tagged `mi.precompiled`.
-"""
-function check_edges(node)
-    parentmi = node.mi_info.mi
-    for child in node.children
-        childmi = child.mi_info.mi
-        if !(isdefined(childmi, :backedges) && parentmi ∈ childmi.backedges)
-            precompile_mi(childmi)
-        end
-        check_edges(child)
+function precompile_newly_inferred(cis)
+    while !isempty(cis)
+        ci = pop!(cis)
+        precompile_mi(ci.def)
     end
-end
-
-function precompile_roots(roots)
-    @assert have_inference_tracking
-    for child in roots
-        precompile_mi(child.mi_info.mi)
-        check_edges(child)
-    end
+    return cis
 end
 
 """
@@ -66,37 +49,21 @@ end
         - indirect runtime-dispatched calls to such methods.
 """
 macro compile_workload(ex::Expr)
-    local iscompiling = if Base.VERSION < v"1.6"
-        :(ccall(:jl_generating_output, Cint, ()) == 1)
-    else
-        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
-    end
-    if have_force_compile
-        ex = quote
-            begin
-                Base.Experimental.@force_compile
-                $(esc(ex))
-            end
-        end
-    else
-        # Use the hack on earlier Julia versions that blocks the interpreter
-        ex = quote
-            while false end
+    local iscompiling = :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
+    ex = quote
+        begin
+            Base.Experimental.@force_compile
             $(esc(ex))
         end
     end
-    if have_inference_tracking
-        ex = quote
-            Core.Compiler.Timings.reset_timings()
-            Core.Compiler.__set_measure_typeinf(true)
-            try
-                $ex
-            finally
-                Core.Compiler.__set_measure_typeinf(false)
-                Core.Compiler.Timings.close_current_timer()
-            end
-            $PrecompileTools.precompile_roots(Core.Compiler.Timings._timings[1].children)
+    ex = quote
+        ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+        try
+            $ex
+        finally
+            ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
         end
+        $PrecompileTools.precompile_newly_inferred(newly_inferred)
     end
     return quote
         if $iscompiling || $PrecompileTools.verbose[]
@@ -128,11 +95,7 @@ runtime dispatches (though they will be precompiled anyway if the runtime-callee
 to your package).
 """
 macro setup_workload(ex::Expr)
-    local iscompiling = if Base.VERSION < v"1.6"
-        :(ccall(:jl_generating_output, Cint, ()) == 1)
-    else
-        :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
-    end
+    local iscompiling = :((ccall(:jl_generating_output, Cint, ()) == 1 && $PrecompileTools.workload_enabled(@__MODULE__)))
     # Ideally we'd like a `let` around this to prevent namespace pollution, but that seem to
     # trigger inference & codegen in undesirable ways (see #16).
     return quote

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -12,13 +12,15 @@ function workload_enabled(mod::Module)
     end
 end
 
-@noinline function precompile_newly_inferred(cis)
+cache_newly_inferred() = ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+
+@noinline function precompile_newly_inferred()
     ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing) # ensure we drop internally references to both newly_inferred arrays so that it is safe to access them here
-    for child in cis # set the must-precompile bit on all new code
+    for child in newly_inferred # set the must-precompile bit on all new code
         precompile_mi((child::Base.CodeInstance).def)
     end
-    append!(Base.newly_inferred, cis) # request the new code be included in the serialized file
-    empty!(cis)
+    append!(Base.newly_inferred, newly_inferred) # request the new code be included in the serialized file
+    empty!(newly_inferred)
     nothing
 end
 
@@ -59,13 +61,12 @@ macro compile_workload(ex::Expr)
         end
     end
     ex = quote
-        ccall(:jl_set_newly_inferred, Cvoid, (Any,), newly_inferred)
+        $PrecompileTools.cache_newly_inferred()
         try
             $ex
         finally
-            ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing)
+            $PrecompileTools.precompile_newly_inferred()
         end
-        $PrecompileTools.precompile_newly_inferred(newly_inferred)
     end
     return quote
         if $iscompiling || $PrecompileTools.verbose[]

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -13,15 +13,13 @@ function workload_enabled(mod::Module)
 end
 
 @noinline function precompile_newly_inferred(cis)
-        ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing) # ensure we drop internally references to both newly_inferred arrays so that it is safe to access them here
-        for child in cis # set the must-precompile bit on all new code
-            precompile_mi((child::Base.CodeInstance).def)
-        end
-        append!(Base.newly_inferred, cis) # request the new code be included in the serialized file
-        empty!(newly_inferred)
-        nothing
-end
-    return cis
+    ccall(:jl_set_newly_inferred, Cvoid, (Any,), nothing) # ensure we drop internally references to both newly_inferred arrays so that it is safe to access them here
+    for child in cis # set the must-precompile bit on all new code
+        precompile_mi((child::Base.CodeInstance).def)
+    end
+    append!(Base.newly_inferred, cis) # request the new code be included in the serialized file
+    empty!(cis)
+    nothing
 end
 
 """

--- a/test/PC_A/src/PC_A.jl
+++ b/test/PC_A/src/PC_A.jl
@@ -6,11 +6,7 @@ struct MyType
     x::Int
 end
 
-if isdefined(Base, :inferencebarrier)
-    inferencebarrier(@nospecialize(arg)) = Base.inferencebarrier(arg)
-else
-    inferencebarrier(@nospecialize(arg)) = Ref{Any}(arg)[]
-end
+inferencebarrier(@nospecialize(arg)) = Base.inferencebarrier(arg)
 
 function call_findfirst(x, list)
     # call a method defined in Base by runtime dispatch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,192 +2,179 @@ using PrecompileTools
 using Test
 using Pkg
 using UUIDs
+using Base: specializations
 
 @testset "PrecompileTools.jl" begin
-    specializations(m::Method) = isdefined(Base, :specializations) ? Base.specializations(m) : m.specializations
-
     push!(LOAD_PATH, @__DIR__)
 
     using PC_A
-    if VERSION >= v"1.8"
-        # Check that calls inside @setup_workload are not precompiled
-        m = which(Tuple{typeof(Base.vect), Vararg{T}} where T)
-        have_mytype = false
-        for mi in specializations(m)
-            mi === nothing && continue
-            have_mytype |= Base.unwrap_unionall(mi.specTypes).parameters[2] === PC_A.MyType
-        end
-        have_mytype && @warn "Code in setup_workload block was precompiled"
-        # Check that calls inside @compile_workload are precompiled
-        m = only(methods(PC_A.call_findfirst))
-        count = 0
-        for mi in specializations(m)
-            mi === nothing && continue
-            sig = Base.unwrap_unionall(mi.specTypes)
-            if sig.parameters[2] == PC_A.MyType && sig.parameters[3] == Vector{PC_A.MyType}
-                count += 1
-            end
-        end
-        @test count == 1
-        # Even one that was runtime-dispatched
-        m = which(Tuple{typeof(findfirst), Base.Fix2{typeof(==), T}, Vector{T}} where T)
-        count = 0
-        for mi in specializations(m)
-            mi === nothing && continue
-            sig = Base.unwrap_unionall(mi.specTypes)
-            if sig.parameters[3] == Vector{PC_A.MyType}
-                count += 1
-            end
-        end
-        @test count == 1
+    # Check that calls inside @setup_workload are not precompiled
+    m = which(Tuple{typeof(Base.vect), Vararg{T}} where T)
+    have_mytype = false
+    for mi in specializations(m)
+        mi === nothing && continue
+        have_mytype |= Base.unwrap_unionall(mi.specTypes).parameters[2] === PC_A.MyType
     end
-
-    if VERSION >= v"1.7"   # so we can use redirect_stderr(f, ::Pipe)
-        pipe = Pipe()
-        id = Base.PkgId(UUID("d38b61e7-59a2-4ef9-b4d3-320bdc69b817"), "PC_B")
-        redirect_stderr(pipe) do
-            @test_throws Exception Base.require(id)
+    have_mytype && @warn "Code in setup_workload block was precompiled"
+    # Check that calls inside @compile_workload are precompiled
+    m = only(methods(PC_A.call_findfirst))
+    count = 0
+    for mi in specializations(m)
+        mi === nothing && continue
+        sig = Base.unwrap_unionall(mi.specTypes)
+        if sig.parameters[2] == PC_A.MyType && sig.parameters[3] == Vector{PC_A.MyType}
+            count += 1
         end
-        close(pipe.in)
-        str = read(pipe.out, String)
-        @test occursin(r"UndefVarError: `?missing_function`? not defined", str)
     end
-
-    if VERSION >= v"1.6"
-        using PC_C
-    end
-
-    if VERSION >= v"1.6"
-        script = """
-        using PC_D
-        exit(isdefined(PC_D, :workload_ran) === parse(Bool, ARGS[1]) ? 0 : 1)
-        """
-
-        projfile = Base.active_project()
-        Pkg.activate("PC_D")
-        Pkg.instantiate()
-        using PC_D
-
-        PrecompileTools.Preferences.set_preferences!(PC_D, "precompile_workload" => false)
-        @test success(run(`$(Base.julia_cmd()) --project=$(joinpath(@__DIR__, "PC_D")) -e $script 0`))
-
-        PrecompileTools.Preferences.delete_preferences!(PC_D, "precompile_workload"; force = true)
-        @test success(run(`$(Base.julia_cmd()) --project=$(joinpath(@__DIR__, "PC_D")) -e $script 1`))
-        Pkg.activate(projfile)
-    end
-
-    if VERSION >= v"1.6"
-        oldval = PrecompileTools.verbose[]
-        PrecompileTools.verbose[] = true
-        mktemp() do path, io
-            redirect_stdout(io) do
-                include(joinpath(@__DIR__, "PC_E", "src", "PC_E.jl"))
-            end
-            close(io)
-            str = read(path, String)
-            @test occursin("MethodInstance for", str)
-            modscope = Base.VERSION >= v"1.7" ? "PC_E." : ""
-            @test occursin("$(modscope)f(::$Int)", str)
-            @test occursin("$(modscope)f(::String)", str)
+    @test count == 1
+    # Even one that was runtime-dispatched
+    m = which(Tuple{typeof(findfirst), Base.Fix2{typeof(==), T}, Vector{T}} where T)
+    count = 0
+    for mi in specializations(m)
+        mi === nothing && continue
+        sig = Base.unwrap_unionall(mi.specTypes)
+        if sig.parameters[3] == Vector{PC_A.MyType}
+            count += 1
         end
-        PrecompileTools.verbose[] = oldval
     end
+    @test count == 1
 
-    if isdefined(PrecompileTools, :invalidation_leaves)
-        # Mimic the format written to `_jl_debug_method_invalidation`
-        # As a source of MethodInstances, `getproperty` has lots
-        m = which(getproperty, (Any, Symbol))
-        mis = Core.MethodInstance[]
-        for mi in specializations(m)
-            length(mis) >= 10 && break
-            mi === nothing && continue
-            push!(mis, mi)
+    pipe = Pipe()
+    id = Base.PkgId(UUID("d38b61e7-59a2-4ef9-b4d3-320bdc69b817"), "PC_B")
+    redirect_stderr(pipe) do
+        @test_throws Exception Base.require(id)
+    end
+    close(pipe.in)
+    str = read(pipe.out, String)
+    @test occursin(r"UndefVarError: `?missing_function`? not defined", str)
+
+    using PC_C
+
+    script = """
+    using PC_D
+    exit(isdefined(PC_D, :workload_ran) === parse(Bool, ARGS[1]) ? 0 : 1)
+    """
+
+    projfile = Base.active_project()
+    Pkg.activate("PC_D")
+    Pkg.instantiate()
+    using PC_D
+
+    PrecompileTools.Preferences.set_preferences!(PC_D, "precompile_workload" => false)
+    @test success(run(`$(Base.julia_cmd()) --project=$(joinpath(@__DIR__, "PC_D")) -e $script 0`))
+
+    PrecompileTools.Preferences.delete_preferences!(PC_D, "precompile_workload"; force = true)
+    @test success(run(`$(Base.julia_cmd()) --project=$(joinpath(@__DIR__, "PC_D")) -e $script 1`))
+    Pkg.activate(projfile)
+
+    oldval = PrecompileTools.verbose[]
+    PrecompileTools.verbose[] = true
+    mktemp() do path, io
+        redirect_stdout(io) do
+            include(joinpath(@__DIR__, "PC_E", "src", "PC_E.jl"))
         end
-        # These mimic the invalidation lists in SnoopCompile's `test/snoopr.jl`
-        invs = Any[mis[1], 0, mis[2], 1, Tuple{}, m, "jl_method_table_insert"]
-        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
-        invs = Any[mis[1], 0, mis[2], 1, mis[3], 1, Tuple{}, m, "jl_method_table_insert"]
-        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2], mis[3]])
-        invs = Any[mis[1], 0, mis[2], 1, Tuple{}, mis[1], 1, mis[3], "jl_method_table_insert", m, "jl_method_table_insert"]
-        @test PrecompileTools.invalidation_leaves(invs) == Set(mis[1:3])
-        invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", m, "jl_method_table_disable"]
-        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
-        invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", mis[3], "jl_method_table_insert", m]
-        @test Set([mis[1], mis[2]]) ⊆ PrecompileTools.invalidation_leaves(invs)
-        invs = Any[mis[1], 1, mis[2], "jl_method_table_insert", mis[2], "invalidate_mt_cache", m, "jl_method_table_insert"]
-        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
-        invs = Any[Tuple{}, "insert_backedges_callee", 55, Any[m], mis[2], "verify_methods", 55]
-        @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
+        close(io)
+        str = read(path, String)
+        @test occursin("MethodInstance for", str)
+        modscope = "PC_E."
+        @test occursin("$(modscope)f(::$Int)", str)
+        @test occursin("$(modscope)f(::String)", str)
+    end
+    PrecompileTools.verbose[] = oldval
 
-        # Add a real invalidation & repair test
-        cproj = Base.active_project()
-        mktempdir() do dir
-            push!(LOAD_PATH, dir)
-            cd(dir) do
-                for ((pkg1, pkg2, pkg3), recompile) in ((("RC_A", "RC_B", "RC_C"), false,),
-                                                        (("RC_D", "RC_E", "RC_F"), true))
-                    Pkg.generate(pkg1)
-                    open(joinpath(dir, pkg1, "src", pkg1*".jl"), "w") do io
-                        println(io, """
-                        module $pkg1
-                        nbits(::Int8) = 8
-                        nbits(::Int16) = 16
-                        call_nbits(c) = nbits(only(c))
-                        begin
-                            Base.Experimental.@force_compile
-                            call_nbits(Any[Int8(5)])
-                        end
-                        end
-                        """)
+    # Mimic the format written to `_jl_debug_method_invalidation`
+    # As a source of MethodInstances, `getproperty` has lots
+    m = which(getproperty, (Any, Symbol))
+    mis = Core.MethodInstance[]
+    for mi in specializations(m)
+        length(mis) >= 10 && break
+        mi === nothing && continue
+        push!(mis, mi)
+    end
+    # These mimic the invalidation lists in SnoopCompile's `test/snoopr.jl`
+    invs = Any[mis[1], 0, mis[2], 1, Tuple{}, m, "jl_method_table_insert"]
+    @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
+    invs = Any[mis[1], 0, mis[2], 1, mis[3], 1, Tuple{}, m, "jl_method_table_insert"]
+    @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2], mis[3]])
+    invs = Any[mis[1], 0, mis[2], 1, Tuple{}, mis[1], 1, mis[3], "jl_method_table_insert", m, "jl_method_table_insert"]
+    @test PrecompileTools.invalidation_leaves(invs) == Set(mis[1:3])
+    invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", m, "jl_method_table_disable"]
+    @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
+    invs = Any[mis[1], 1, mis[2], "jl_method_table_disable", mis[3], "jl_method_table_insert", m]
+    @test Set([mis[1], mis[2]]) ⊆ PrecompileTools.invalidation_leaves(invs)
+    invs = Any[mis[1], 1, mis[2], "jl_method_table_insert", mis[2], "invalidate_mt_cache", m, "jl_method_table_insert"]
+    @test PrecompileTools.invalidation_leaves(invs) == Set([mis[1], mis[2]])
+    invs = Any[Tuple{}, "insert_backedges_callee", 55, Any[m], mis[2], "verify_methods", 55]
+    @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
+
+    # Add a real invalidation & repair test
+    cproj = Base.active_project()
+    mktempdir() do dir
+        push!(LOAD_PATH, dir)
+        cd(dir) do
+            for ((pkg1, pkg2, pkg3), recompile) in ((("RC_A", "RC_B", "RC_C"), false,),
+                                                    (("RC_D", "RC_E", "RC_F"), true))
+                Pkg.generate(pkg1)
+                open(joinpath(dir, pkg1, "src", pkg1*".jl"), "w") do io
+                    println(io, """
+                    module $pkg1
+                    nbits(::Int8) = 8
+                    nbits(::Int16) = 16
+                    call_nbits(c) = nbits(only(c))
+                    begin
+                        Base.Experimental.@force_compile
+                        call_nbits(Any[Int8(5)])
                     end
-                    Pkg.generate(pkg2)
-                    Pkg.activate(joinpath(dir, pkg2))
-                    Pkg.develop(PackageSpec(path=joinpath(dir, pkg1)))
-                    open(joinpath(dir, pkg2, "src", pkg2*".jl"), "w") do io
-                        println(io, """
-                        module $pkg2
-                        using $pkg1
-                        $(pkg1).nbits(::Int32) = 32
-                        end
-                        """)
                     end
-                    # pkg3 is like a "Startup" package that recompiles the invalidations from loading the "code universe"
-                    Pkg.generate(pkg3)
-                    Pkg.activate(joinpath(dir, pkg3))
-                    Pkg.develop(PackageSpec(path=joinpath(dir, pkg2)))
-                    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))   # depend on PrecompileTools
-                    open(joinpath(dir, pkg3, "src", pkg3*".jl"), "w") do io
-                        if recompile
-                            println(io, """
-                            module $pkg3
-                            using PrecompileTools
-                            @recompile_invalidations using $pkg2
-                            end
-                            """)
-                        else
-                            println(io, """
-                            module $pkg3
-                            using PrecompileTools
-                            using $pkg2
-                            end
-                            """)
-                        end
-                    end
-
-                    @eval using $(Symbol(pkg3))
-                    mod3 = Base.@invokelatest getglobal(@__MODULE__, Symbol(pkg3))
-                    mod2 = Base.@invokelatest getglobal(mod3, Symbol(pkg2))
-                    mod1 = Base.@invokelatest getglobal(mod2, Symbol(pkg1))
-                    m = only(methods(mod1.call_nbits))
-                    mi = first(specializations(m))
-                    wc = Base.get_world_counter()
-                    @test recompile ? mi.cache.max_world >= wc : mi.cache.max_world < wc
+                    """)
                 end
+                Pkg.generate(pkg2)
+                Pkg.activate(joinpath(dir, pkg2))
+                Pkg.develop(PackageSpec(path=joinpath(dir, pkg1)))
+                open(joinpath(dir, pkg2, "src", pkg2*".jl"), "w") do io
+                    println(io, """
+                    module $pkg2
+                    using $pkg1
+                    $(pkg1).nbits(::Int32) = 32
+                    end
+                    """)
+                end
+                # pkg3 is like a "Startup" package that recompiles the invalidations from loading the "code universe"
+                Pkg.generate(pkg3)
+                Pkg.activate(joinpath(dir, pkg3))
+                Pkg.develop(PackageSpec(path=joinpath(dir, pkg2)))
+                Pkg.develop(PackageSpec(path=dirname(@__DIR__)))   # depend on PrecompileTools
+                open(joinpath(dir, pkg3, "src", pkg3*".jl"), "w") do io
+                    if recompile
+                        println(io, """
+                        module $pkg3
+                        using PrecompileTools
+                        @recompile_invalidations using $pkg2
+                        end
+                        """)
+                    else
+                        println(io, """
+                        module $pkg3
+                        using PrecompileTools
+                        using $pkg2
+                        end
+                        """)
+                    end
+                end
+
+                @eval using $(Symbol(pkg3))
+                mod3 = Base.@invokelatest getglobal(@__MODULE__, Symbol(pkg3))
+                mod2 = Base.@invokelatest getglobal(mod3, Symbol(pkg2))
+                mod1 = Base.@invokelatest getglobal(mod2, Symbol(pkg1))
+                m = only(methods(mod1.call_nbits))
+                mi = first(specializations(m))
+                wc = Base.get_world_counter()
+                @test recompile ? mi.cache.max_world >= wc : mi.cache.max_world < wc
             end
-            pop!(LOAD_PATH)
         end
-        Pkg.activate(cproj)
+        pop!(LOAD_PATH)
     end
+    Pkg.activate(cproj)
 
     pop!(LOAD_PATH)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,9 @@ using Base: specializations
     invs = Any[Tuple{}, "insert_backedges_callee", 55, Any[m], mis[2], "verify_methods", 55]
     @test PrecompileTools.invalidation_leaves(invs) == Set([mis[2]])
 
+    # Coverage isn't on during package precompilation, so let's test a few things here
+    PrecompileTools.precompile_mi(mis[1])
+
     # Add a real invalidation & repair test
     cproj = Base.active_project()
     mktempdir() do dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ using Base: specializations
     for mi in specializations(m)
         mi === nothing && continue
         sig = Base.unwrap_unionall(mi.specTypes)
-        if sig.parameters[2] == PC_A.MyType && sig.parameters[3] == Vector{PC_A.MyType}
+        if sig == Tuple{typeof(PC_A.call_findfirst), PC_A.MyType, Vector{PC_A.MyType}}
             count += 1
         end
     end


### PR DESCRIPTION
xref https://github.com/JuliaLang/julia/pull/57074

The old `Compiler.Timings` infrastructure is disabled, so here we
leverage the same `newly_compiled` infrastructure used during
precompilation.

CC @vtjnash. There's one failing test that needs some investigation.