### PR TITLE
Docstring fixes

### DIFF
--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -15,7 +15,7 @@ end
     check_edges(node)
 
 Recursively ensure that all callees of `node` are precompiled. This is (rarely) necessary
-because sometimes there is no backedge from callee to caller (xref https://github.com/JuliaLang/julia/issues/49617),
+because sometimes there is no backedge from callee to caller (xref [JuliaLang/julia#49617](https://github.com/JuliaLang/julia/issues/49617)),
 and `staticdata.c` relies on the backedge to trace back to a MethodInstance that is tagged `mi.precompiled`.
 """
 function check_edges(node)
@@ -40,13 +40,13 @@ end
 """
     @compile_workload f(args...)
 
-`precompile` (and save in the compile_workload file) any method-calls that occur inside the expression. All calls (direct or indirect) inside a
+`precompile` (and save in the `compile_workload` file) any method-calls that occur inside the expression. All calls (direct or indirect) inside a
 `@compile_workload` block will be cached.
 
 `@compile_workload` has three key features:
 
 1. code inside runs only when the package is being precompiled (i.e., a `*.ji`
-   precompile compile_workload file is being written)
+   precompile `compile_workload` file is being written)
 2. the interpreter is disabled, ensuring your calls will be compiled
 3. both direct and indirect callees will be precompiled, even for methods defined in other packages
    and even for runtime-dispatched callees (requires Julia 1.8 and above).


### PR DESCRIPTION
- `compile_workload` needs to be code-quoted to avoid interpreting `_` as
  beginning italics
- Make "xref" link to julia issue an actual link