### PR TITLE
Ensure compilation happens after logging starts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - run: julia --code-coverage=none --startup=no --project test/without_coverage.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,21 @@
 name = "PrecompileTools"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-authors = ["Tim Holy <tim.holy@gmail.com>", "t-bltg <tf.bltg@gmail.com>", "and contributors"]
 version = "1.3.0"
+authors = ["Tim Holy <tim.holy@gmail.com>", "t-bltg <tf.bltg@gmail.com>", "and contributors"]
 
 [deps]
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
+InteractiveUtils = "1.11.0"
 Preferences = "1"
 julia = "1.12"
 
 [extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Pkg", "Test", "UUIDs"]
+test = ["InteractiveUtils", "Pkg", "Test", "UUIDs"]

--- a/test/AliasTables/Manifest.toml
+++ b/test/AliasTables/Manifest.toml
@@ -1,0 +1,51 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.0-DEV"
+manifest_format = "2.0"
+project_hash = "08b5cd69f1c3c631130172e148f3d7bf0afe42df"
+
+[[deps.AliasTables]]
+deps = ["PrecompileTools"]
+path = "."
+uuid = "beccad7b-8a6a-4466-a02c-5791472d17ea"
+version = "0.1.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+path = "../.."
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"

--- a/test/AliasTables/Project.toml
+++ b/test/AliasTables/Project.toml
@@ -1,0 +1,11 @@
+name = "AliasTables"
+uuid = "beccad7b-8a6a-4466-a02c-5791472d17ea"
+version = "0.1.0"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[compat]
+Random = "1.11.0"

--- a/test/AliasTables/src/AliasTables.jl
+++ b/test/AliasTables/src/AliasTables.jl
@@ -1,0 +1,18 @@
+module AliasTables
+
+using Random
+using PrecompileTools
+
+export AliasTable
+
+struct AliasTable{T}
+    x::T
+end
+Base.rand(x::AliasTable) = rand(x.x)
+
+PrecompileTools.@compile_workload begin
+    at = AliasTable([1.0, 2.0])
+    rand(at)
+end
+
+end

--- a/test/MSort/Manifest.toml
+++ b/test/MSort/Manifest.toml
@@ -1,0 +1,42 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.0-DEV"
+manifest_format = "2.0"
+project_hash = "54196cb61d86afd465157edc4da76dcf0e248920"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.MSort]]
+deps = ["PrecompileTools"]
+path = "."
+uuid = "75c9a4e7-9bfb-42c4-89fa-37abaaaaefd3"
+version = "0.1.0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+path = "../.."
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"

--- a/test/MSort/Project.toml
+++ b/test/MSort/Project.toml
@@ -1,0 +1,7 @@
+name = "MSort"
+uuid = "75c9a4e7-9bfb-42c4-89fa-37abaaaaefd3"
+version = "0.1.0"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"

--- a/test/MSort/src/MSort.jl
+++ b/test/MSort/src/MSort.jl
@@ -1,0 +1,57 @@
+module MSort
+
+# issue #26
+
+using PrecompileTools
+
+function quicksort(
+    v::Vector{T};
+    lo::Int = 1,
+    hi::Int = length(v),
+) where {T <: Union{Int64, Float64}}
+    x = copy(v)
+    quick!(x, lo, hi)
+    x
+end
+
+function partition(
+    xp::Vector{T},
+    pivot::T,
+    left::Int,
+    right::Int,
+) where {T <: Union{Int64, Float64}}
+    while left <= right
+        while xp[left] < pivot
+            left += 1
+        end
+        while pivot < xp[right]
+            right -= 1
+        end
+        if left <= right
+            xp[left], xp[right] = xp[right], xp[left]
+            left += 1
+            right -= 1
+        end
+    end
+    left, right
+end
+
+function quick!(
+    xp::Vector{T},
+    i::Int,
+    j::Int,
+) where {T <: Union{Int64, Float64}}
+    if j > i
+        left, right = partition(xp, xp[(j+i)>>>1], i, j)
+        quick!(xp, i, right)
+        quick!(xp, left, j)
+    end
+end
+
+@setup_workload begin
+    @compile_workload begin
+        quicksort(rand(64))
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using PrecompileTools
 using Test
 using Pkg
 using UUIDs
-using InteractiveUtils
 using Base: specializations
 
 @testset "PrecompileTools.jl" begin
@@ -82,22 +81,6 @@ using Base: specializations
         @test occursin("$(modscope)f(::String)", str)
     end
     PrecompileTools.verbose[] = oldval
-
-    using MSort
-    using AliasTables
-    x = rand(64)
-    pipe = Pipe()
-    oldstderr = stderr
-    redirect_stderr(pipe)
-    @trace_compile begin
-        MSort.quicksort(x)
-        at = AliasTable([1.0, 2.0])
-        rand(at)
-    end
-    close(pipe.in)
-    redirect_stderr(oldstderr)
-    str = read(pipe.out, String)
-    @test isempty(str)
 
     ## @recompile_invalidations
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using PrecompileTools
 using Test
 using Pkg
 using UUIDs
+using InteractiveUtils
 using Base: specializations
 
 @testset "PrecompileTools.jl" begin
@@ -81,6 +82,24 @@ using Base: specializations
         @test occursin("$(modscope)f(::String)", str)
     end
     PrecompileTools.verbose[] = oldval
+
+    using MSort
+    using AliasTables
+    x = rand(64)
+    pipe = Pipe()
+    oldstderr = stderr
+    redirect_stderr(pipe)
+    @trace_compile begin
+        MSort.quicksort(x)
+        at = AliasTable([1.0, 2.0])
+        rand(at)
+    end
+    close(pipe.in)
+    redirect_stderr(oldstderr)
+    str = read(pipe.out, String)
+    @test isempty(str)
+
+    ## @recompile_invalidations
 
     # Mimic the format written to `_jl_debug_method_invalidation`
     # As a source of MethodInstances, `getproperty` has lots

--- a/test/without_coverage.jl
+++ b/test/without_coverage.jl
@@ -1,0 +1,27 @@
+using PrecompileTools
+using Test
+using InteractiveUtils
+
+@testset "No-coverage tests" begin
+    @assert Base.JLOptions().code_coverage == 0 "These tests should be run with coverage disabled"
+
+    push!(LOAD_PATH, @__DIR__)
+
+    using MSort
+    using AliasTables
+    x = rand(64)
+    pipe = Pipe()
+    oldstderr = stderr
+    redirect_stderr(pipe)
+    @trace_compile begin
+        MSort.quicksort(x)
+        at = AliasTable([1.0, 2.0])
+        rand(at)
+    end
+    close(pipe.in)
+    redirect_stderr(oldstderr)
+    str = read(pipe.out, String)
+    @test isempty(str)
+
+    pop!(LOAD_PATH)
+end


### PR DESCRIPTION
If compilation of the workload happens before the logging system is
initialized, many CodeInstances may be missed. This exploits
`Core.@latestworld` to prevent inference from proceeding into the
workload. It removes the `@force_compile`, which introduces
some risk that even the workload will be interpreted.

Also wraps the `@setup_workload` block with a `let`.

Fixes #17
Fixes #26
Fixes #37
Closes #40
Closes https://github.com/JuliaLang/julia/issues/57957

CC @vtjnash