### PR TITLE
Force `precompile_workloads` to always be a compile-time preference

### DIFF
--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -1,5 +1,9 @@
 const newly_inferred = Core.CodeInstance[]   # only used to support verbose[]
 
+# This dummy call ensures that `precompile_workloads` is recorded as a
+# compile-time preference for the `PrecompileTools` module.
+load_preference(@__MODULE__, "precompile_workloads", true)
+
 function workload_enabled(mod::Module)
     try
         if load_preference(@__MODULE__, "precompile_workloads", true)


### PR DESCRIPTION
In order for a preference to be considered a compile-time preference (and therefore for it to invalidate a precompilation cache file) the preference must be read during compilation of a module.  The `precompile_workloads` preference was not being read during `PrecompileTools`' compilation, but during compilation of modules using `PrecompileTools` (which is harmless, but does not mark the preference as compile-time for `PrecompileTools`, of course).

This adds a dummy read of the preference in order to mark it as compile-time, so that adding a `precompile_workloads = false` in your `LocalPreferences.toml` properly invalidates everything.