### PR TITLE
Add compile workload timing prints when PRECOMPILETOOLS_TIMING=1

### DIFF
--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -1,5 +1,16 @@
 const newly_inferred = Core.CodeInstance[]   # only used to support verbose[]
 
+const timing_enabled = Ref{Union{Nothing,Bool}}(nothing)  # lazy lookup of PRECOMPILETOOLS_TIMING
+
+function check_timing_enabled()
+    val = timing_enabled[]
+    if val === nothing
+        val = Base.get_bool_env("PRECOMPILETOOLS_TIMING", false)
+        timing_enabled[] = val
+    end
+    return val::Bool
+end
+
 function workload_enabled(mod::Module)
     try
         if load_preference(@__MODULE__, "precompile_workloads", true)
@@ -13,6 +24,14 @@ function workload_enabled(mod::Module)
 end
 
 @noinline is_generating_output() = ccall(:jl_generating_output, Cint, ()) == 1
+
+function print_timed(t_ns::UInt64, exprstr::String)
+    ms = round(Int, t_ns / 1_000_000)
+    if occursin("\n", exprstr) # when multiline print nicely
+        exprstr = "\n" * exprstr
+    end
+    @info "$(lpad(ms, 7)) ms: $exprstr"
+end
 
 macro latestworld_if_toplevel()
     Expr(Symbol("latestworld-if-toplevel"))
@@ -35,6 +54,33 @@ function tag_newly_inferred_disable()
         end
     end
     return nothing
+end
+
+
+function wrap_with_timing(ex::Expr)
+    if ex.head === :block
+        new_args = Any[]
+        for arg in ex.args
+            if arg isa LineNumberNode
+                push!(new_args, arg)
+            else
+                exprstr = string(arg)
+                push!(new_args, quote
+                    if $PrecompileTools.check_timing_enabled()
+                        local _t0 = time_ns()
+                        $(arg)
+                        local _t1 = time_ns()
+                        $PrecompileTools.print_timed(_t1 - _t0, $(exprstr))
+                    else
+                        $(arg)
+                    end
+                end)
+            end
+        end
+        return Expr(:block, new_args...)
+    else
+        return ex
+    end
 end
 
 """
@@ -67,10 +113,11 @@ end
 """
 macro compile_workload(ex::Expr)
     local iscompiling = :($PrecompileTools.is_generating_output() && $PrecompileTools.workload_enabled(@__MODULE__))
+    timed_ex = wrap_with_timing(ex)
     ex = quote
         begin
             $PrecompileTools.@latestworld_if_toplevel  # block inference from proceeding beyond this point (xref https://github.com/JuliaLang/julia/issues/57957)
-            $(esc(ex))
+            $(esc(timed_ex))
         end
     end
     ex = quote

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -115,7 +115,7 @@ macro compile_workload(ex::Expr)
     local iscompiling = :($PrecompileTools.is_generating_output() && $PrecompileTools.workload_enabled(@__MODULE__))
     timed_ex = wrap_with_timing(ex)
     ex = quote
-        begin
+        @time "@compile_workload" begin
             $PrecompileTools.@latestworld_if_toplevel  # block inference from proceeding beyond this point (xref https://github.com/JuliaLang/julia/issues/57957)
             $(esc(timed_ex))
         end


### PR DESCRIPTION
Just gives one level of granularity per top line in the expr, and a total `@time` at the end. (reassuringly GLMakie spends 94% of its time compiling)
```
% PRECOMPILETOOLS_TIMING=1 julia -q
julia> using GLMakie
[ Info: Precompiling GLMakie [e9467ef8-e4e7-5192-8a1a-b1aee30e663a] (caches not reused: 1 for dependency identifier changed)
[ Info:       4 ms: GLMakie.activate!()
[ Info:    1255 ms: screen = GLMakie.singleton_screen(false)
[ Info:     319 ms: close(screen)
[ Info:      71 ms: destroy!(screen)
[ Info:       0 ms: base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
[ Info:       0 ms: shared_precompile = joinpath(base_path, "shared-precompile.jl")
 17.258217 seconds (144.47 M allocations: 8.297 GiB, 8.12% gc time, 94.54% compilation time: 1% of which was recompilation)
[ Info:   17270 ms: #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:26 =# @time include(shared_precompile)
┌ Info:     167 ms:
│ try
│     #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:28 =#
│     display(plot(x); visible = false)
│ catch
│     #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:29 =#
└ end
[ Info:       0 ms: Makie.CURRENT_FIGURE[] = nothing
[ Info:      38 ms: screen = Screen(Scene())
[ Info:       1 ms: refresh_func = refreshwindowcb(screen)
[ Info:       2 ms: refresh_func(to_native(screen))
[ Info:      20 ms: close(screen)
[ Info:       9 ms: screen = empty_screen(false)
[ Info:       2 ms: close(screen)
[ Info:       3 ms: destroy!(screen)
[ Info:       6 ms: screen = empty_screen(false, false, nothing)
[ Info:       4 ms: destroy!(screen)
[ Info:       0 ms: config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}())
[ Info:       4 ms: screen = Screen(Scene(), config, nothing, (MIME"image/png")(); visible = false, start_renderloop = false)
[ Info:       0 ms: close(screen)
[ Info:       0 ms: config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}())
[ Info:       2 ms: screen = Screen(Scene(), config; visible = false, start_renderloop = false)
[ Info:       0 ms: close(screen)
[ Info:      63 ms: closeall(; empty_shader = false)
[ Info:       1 ms: #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:52 =# @assert isempty(SCREEN_REUSE_POOL)
[ Info:       0 ms: #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:53 =# @assert isempty(ALL_SCREENS)
[ Info:       1 ms: #= /Users/ian/Documents/GitHub/Makie.jl/GLMakie/src/precompiles.jl:54 =# @assert isempty(SINGLETON_SCREEN)
@compile_workload: 19.292506 seconds (158.20 M allocations: 8.949 GiB, 7.76% gc time, 93.73% compilation time: 1% of which was recompilation)
```