### PR TITLE
The current code has a bounds safety issue that could cause a BoundsError

### DIFF
--- a/src/invalidations.jl
+++ b/src/invalidations.jl
@@ -73,7 +73,7 @@ function invalidation_leaves(listi, liste)
 
     # Process edge-validation events
     i, ilast = firstindex(liste), lastindex(liste)
-    while i <= ilast
+    while i+1 <= ilast
         tag = liste[i + 1]   # the tag is always second
         if tag == "method_globalref"
             push!(umis, Core.Compiler.get_ci_mi(liste[i + 2]))


### PR DESCRIPTION
### Problem : The current code has a bounds safety issue that could cause a BoundsError 
example : when reached `i = lastindex` **tag** stores val `lastindex+1` that can cause problem 

### Change

Current code Is:

```julia
i, ilast = firstindex(liste), lastindex(liste)
while i <= ilast
    tag = liste[i + 1]
    ...
end
```

change i DID:

```julia
i, ilast = firstindex(liste), lastindex(liste)
while i + 1 <= ilast
    tag = liste[i + 1]
    ...
end
```

### can Do this if wanted an error log

at the end of the loop, if `i <= ilast`, you can throw a clearer error:

```julia
if i <= ilast
    error("Malformed invalidation list: unexpected trailing entries")
end
```