### PR TITLE
record if precompile tools is fully disabled at precompile time so its cachefile invalidates properly when changed

### DIFF
--- a/src/PrecompileTools.jl
+++ b/src/PrecompileTools.jl
@@ -5,6 +5,7 @@ using Preferences
 export @setup_workload, @compile_workload, @recompile_invalidations
 
 const verbose = Ref(false)    # if true, prints all the precompiles
+const enabled = @load_preference("precompile_workloads", true)::Bool
 
 function precompile_mi(mi::Core.MethodInstance)
     precompile(mi)

--- a/src/workloads.jl
+++ b/src/workloads.jl
@@ -1,12 +1,9 @@
 const newly_inferred = Core.CodeInstance[]   # only used to support verbose[]
 
 function workload_enabled(mod::Module)
+    enabled || return false
     try
-        if load_preference(@__MODULE__, "precompile_workloads", true)
-            return load_preference(mod, "precompile_workload", true)
-        else
-            return false
-        end
+        return load_preference(mod, "precompile_workload", true)::Bool
     catch
         true
     end


### PR DESCRIPTION
This might be fixed on 1.13 (https://github.com/JuliaLang/julia/pull/61214) but still good to fix here. 

cc @topolarity